### PR TITLE
database relations restructured

### DIFF
--- a/app/backend/src/main/java/com/wishlist/models/Item.java
+++ b/app/backend/src/main/java/com/wishlist/models/Item.java
@@ -1,19 +1,11 @@
 package com.wishlist.models;
 
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
 
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-
-@Document
 public class Item {
     @Id
     private String id;
     private String name;
-    @ManyToOne
-    @JoinColumn(name = "shoppingListId")
-    private ShoppingList shoppingList;
 
     public Item() {
     }
@@ -38,11 +30,4 @@ public class Item {
         this.name = name;
     }
 
-    public ShoppingList getShoppingList() {
-        return shoppingList;
-    }
-
-    public void setShoppingList(ShoppingList shoppingList) {
-        this.shoppingList = shoppingList;
-    }
 }

--- a/app/backend/src/main/java/com/wishlist/models/Role.java
+++ b/app/backend/src/main/java/com/wishlist/models/Role.java
@@ -1,20 +1,17 @@
 package com.wishlist.models;
 
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import javax.persistence.*;
 
-@Entity
-@Table(name = "roles")
-public class Role {
 
+@Document
+public class Role {
     @Id
     private String id;
-
-    @Enumerated(EnumType.STRING)
     private UserRoleEnum name;
-
     public Role() {
     }
-
     public String getId() {
         return id;
     }
@@ -30,6 +27,5 @@ public class Role {
     public void setName(UserRoleEnum role) {
         this.name = role;
     }
-
 
 }

--- a/app/backend/src/main/java/com/wishlist/models/ShoppingList.java
+++ b/app/backend/src/main/java/com/wishlist/models/ShoppingList.java
@@ -3,24 +3,25 @@ package com.wishlist.models;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import java.util.List;
 
 @Document
 public class ShoppingList {
     @Id
     private String id;
-
-    @OneToMany(mappedBy = "shoppingList")
     private List<Item> itemList;
-    @ManyToOne
-    @JoinColumn(name = "userId")
     private User user;
+    private String familyId;
 
     public ShoppingList() {
+    }
+
+    public String getFamilyId() {
+        return familyId;
+    }
+
+    public void setFamilyId(String familyId) {
+        this.familyId = familyId;
     }
 
     public ShoppingList(List<Item> itemList) {

--- a/app/backend/src/main/java/com/wishlist/models/User.java
+++ b/app/backend/src/main/java/com/wishlist/models/User.java
@@ -1,11 +1,9 @@
 package com.wishlist.models;
 
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDate;
-import javax.persistence.*;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -16,15 +14,11 @@ public class User {
     private String id;
     private String name;
     private String surname;
-    @Indexed(unique = true)
     private String email;
     private String password;
     private LocalDate dob;
-    @OneToMany(mappedBy = "user")
+    private String familyId;
     private List<ShoppingList> shoppingLists;
-
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
     private Set<Role> roles = new HashSet<>();
 
     public User() {
@@ -97,4 +91,12 @@ public class User {
     public void setDob(LocalDate dob) {
         this.dob = dob;
     }
+    public String getFamilyId() {
+        return familyId;
+    }
+
+    public void setFamilyId(String familyId) {
+        this.familyId = familyId;
+    }
+
 }

--- a/app/backend/src/main/java/com/wishlist/services/ShoppingListService.java
+++ b/app/backend/src/main/java/com/wishlist/services/ShoppingListService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 public class ShoppingListService implements IShoppingListService {


### PR DESCRIPTION
1. Removal of JPA annotations since we use Mongo.
2. Removing ShoppingList inside Item, since we do not need embedding shoppingList inside Item. The shopping list has items already embedded in itself.
3. Removing JPA annotations in roles.
4. Adding familyID reference inside ShoppingList model since we need to connect ShoppingList to family. Should consider removing User from shopping list since it may be better to just link with the family.
5. Adding familyID reference at user.

The point is. We should not embbed one entity in another. Family should have embedded users, shopping list, and shopping list should have items embedded in itself, when we call family object we can see in this format top to bottom.
Family {
users: {}
shopping-list: {
items: {}
}

But considering bottom to top. Items don't need but can have a shopping list ID reference, ShoppingList can have familyID reference, and the user can have a familyId reference, but not the whole family stored inside him.